### PR TITLE
Fix SENTRY_RELEASE getvar

### DIFF
--- a/src/watcloud_utils/sentry.py
+++ b/src/watcloud_utils/sentry.py
@@ -43,7 +43,7 @@ def set_up_sentry(
     image_rev = build_labels.get("org.opencontainers.image.revision", "unknown_rev")
 
     SENTRY_RELEASE = (
-        getvar("SENTRY_RELEASE", logger=logger)
+        getvar(Var.SENTRY_RELEASE, logger=logger)
         or f"{image_title}:{image_version}@{image_rev}"
     )
 


### PR DESCRIPTION
There's a typo where we used a string in `getvar`. Strange that type checking didn't catch this.