### PR TITLE
Warn that SENTRY_RELEASE is missing only when BUILD_INFO is missing

### DIFF
--- a/src/watcloud_utils/sentry.py
+++ b/src/watcloud_utils/sentry.py
@@ -43,7 +43,7 @@ def set_up_sentry(
     image_rev = build_labels.get("org.opencontainers.image.revision", "unknown_rev")
 
     SENTRY_RELEASE = (
-        getvar(Vars.SENTRY_RELEASE, logger=logger)
+        getvar(Vars.SENTRY_RELEASE, warn_if_missing=not BUILD_INFO, logger=logger)
         or f"{image_title}:{image_version}@{image_rev}"
     )
 


### PR DESCRIPTION
When BUILD_INFO is present, we have a valid fallback for SENTRY_RELEASE.